### PR TITLE
feat(cs): T队可见掉落C4轮廓并提升远距离可见性

### DIFF
--- a/src/main/java/com/phasetranscrystal/blockoffensive/mixin/client/C4ItemOutlineMixin.java
+++ b/src/main/java/com/phasetranscrystal/blockoffensive/mixin/client/C4ItemOutlineMixin.java
@@ -1,0 +1,80 @@
+package com.phasetranscrystal.blockoffensive.mixin.client;
+
+import com.phasetranscrystal.blockoffensive.item.BOItemRegister;
+import com.phasetranscrystal.fpsmatch.common.client.FPSMClient;
+import com.phasetranscrystal.fpsmatch.common.client.data.FPSMClientGlobalData;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@OnlyIn(Dist.CLIENT)
+@Mixin(Entity.class)
+public abstract class C4ItemOutlineMixin {
+
+    private static final int T_C4_OUTLINE_COLOR = 0xEAC055;
+    private static final double C4_OUTLINE_RENDER_DISTANCE = 128.0D;
+    private static final double C4_OUTLINE_RENDER_DISTANCE_SQR = C4_OUTLINE_RENDER_DISTANCE * C4_OUTLINE_RENDER_DISTANCE;
+
+    @Inject(method = "isCurrentlyGlowing", at = @At("HEAD"), cancellable = true)
+    private void blockoffensive$showDroppedC4OutlineForTOnly(CallbackInfoReturnable<Boolean> cir) {
+        Entity self = (Entity) (Object) this;
+        if (!isDroppedC4Item(self)) {
+            return;
+        }
+
+        cir.setReturnValue(canLocalPlayerSeeDroppedC4Outline());
+    }
+
+    @Inject(method = "getTeamColor", at = @At("HEAD"), cancellable = true)
+    private void blockoffensive$setDroppedC4OutlineColor(CallbackInfoReturnable<Integer> cir) {
+        Entity self = (Entity) (Object) this;
+        if (!isDroppedC4Item(self)) {
+            return;
+        }
+
+        if (canLocalPlayerSeeDroppedC4Outline()) {
+            cir.setReturnValue(T_C4_OUTLINE_COLOR);
+        }
+    }
+
+    @Inject(method = "shouldRenderAtSqrDistance", at = @At("HEAD"), cancellable = true)
+    private void blockoffensive$extendDroppedC4RenderDistance(double distanceSqr, CallbackInfoReturnable<Boolean> cir) {
+        Entity self = (Entity) (Object) this;
+        if (!isDroppedC4Item(self)) {
+            return;
+        }
+
+        if (canLocalPlayerSeeDroppedC4Outline()) {
+            cir.setReturnValue(distanceSqr < C4_OUTLINE_RENDER_DISTANCE_SQR);
+        }
+    }
+
+    private static boolean isDroppedC4Item(Entity entity) {
+        if (!(entity instanceof ItemEntity itemEntity)) {
+            return false;
+        }
+        ItemStack stack = itemEntity.getItem();
+        return stack.is(BOItemRegister.C4.get());
+    }
+
+    private static boolean canLocalPlayerSeeDroppedC4Outline() {
+        Minecraft minecraft = Minecraft.getInstance();
+        LocalPlayer localPlayer = minecraft.player;
+        if (localPlayer == null) {
+            return false;
+        }
+
+        FPSMClientGlobalData data = FPSMClient.getGlobalData();
+        return data.isCurrentGameType("cs")
+                && data.isInNormalTeam()
+                && data.isCurrentTeam("t");
+    }
+}

--- a/src/main/resources/blockoffensive.mixins.json
+++ b/src/main/resources/blockoffensive.mixins.json
@@ -13,6 +13,7 @@
     "StepSoundMixin"
   ],
   "client": [
+    "client.C4ItemOutlineMixin",
     "PlayerRendererMixin"
   ],
   "injectors": {

--- a/src/test/java/com/phasetranscrystal/blockoffensive/issues/BlockOffensiveIssueRegressionTest.java
+++ b/src/test/java/com/phasetranscrystal/blockoffensive/issues/BlockOffensiveIssueRegressionTest.java
@@ -14,6 +14,8 @@ class BlockOffensiveIssueRegressionTest {
     private static final Path CS_MAP = Path.of("src/main/java/com/phasetranscrystal/blockoffensive/map/CSMap.java");
     private static final Path CS_GAME_EVENTS = Path.of("src/main/java/com/phasetranscrystal/blockoffensive/map/CSGameEvents.java");
     private static final Path CS_COMMAND = Path.of("src/main/java/com/phasetranscrystal/blockoffensive/command/CSCommand.java");
+    private static final Path C4_OUTLINE_MIXIN = Path.of("src/main/java/com/phasetranscrystal/blockoffensive/mixin/client/C4ItemOutlineMixin.java");
+    private static final Path MIXINS_CONFIG = Path.of("src/main/resources/blockoffensive.mixins.json");
 
     @Test
     void csTabRendererHandlesMissingTeamsAndPlayerData() throws IOException {
@@ -54,9 +56,24 @@ class BlockOffensiveIssueRegressionTest {
 
     @Test
     void droppedObjectiveItemsDoNotUseVanillaGlowing() throws IOException {
-        assertFalse(Files.readString(CS_MAP).contains("setGlowingTag(true)"));
-        assertFalse(Files.readString(CS_GAME_MAP).contains("setGlowingTag(true)"));
-        assertFalse(Files.readString(CS_GAME_EVENTS).contains("setGlowingTag(true)"));
+        assertFalse(Files.readString(CS_MAP).contains("setGlowingTag("));
+        assertFalse(Files.readString(CS_GAME_MAP).contains("setGlowingTag("));
+        assertFalse(Files.readString(CS_GAME_EVENTS).contains("setGlowingTag("));
+    }
+
+    @Test
+    void droppedC4OutlineIsClientSideAndTTeamOnly() throws IOException {
+        String mixin = Files.readString(C4_OUTLINE_MIXIN);
+        String mixinsConfig = Files.readString(MIXINS_CONFIG);
+
+        assertTrue(mixin.contains("@OnlyIn(Dist.CLIENT)"));
+        assertTrue(mixin.contains("isCurrentGameType(\"cs\")"));
+        assertTrue(mixin.contains("isCurrentTeam(\"t\")"));
+        assertTrue(mixin.contains("stack.is(BOItemRegister.C4.get())"));
+        assertTrue(mixin.contains("shouldRenderAtSqrDistance"));
+        assertTrue(mixin.contains("C4_OUTLINE_RENDER_DISTANCE_SQR"));
+        assertTrue(mixin.contains("cir.setReturnValue(canLocalPlayerSeeDroppedC4Outline())"));
+        assertTrue(mixinsConfig.contains("client.C4ItemOutlineMixin"));
     }
 
     @Test

--- a/src/test/java/com/phasetranscrystal/blockoffensive/map/CSIssueSourceGuardTest.java
+++ b/src/test/java/com/phasetranscrystal/blockoffensive/map/CSIssueSourceGuardTest.java
@@ -54,9 +54,9 @@ class CSIssueSourceGuardTest {
         String gameMap = read("src/main/java/com/phasetranscrystal/blockoffensive/map/CSGameMap.java");
         String gameEvents = read("src/main/java/com/phasetranscrystal/blockoffensive/map/CSGameEvents.java");
 
-        assertFalse(csMap.contains("setGlowingTag(true)"));
-        assertFalse(gameMap.contains("setGlowingTag(true)"));
-        assertFalse(gameEvents.contains("setGlowingTag(true)"));
+        assertFalse(csMap.contains("setGlowingTag("));
+        assertFalse(gameMap.contains("setGlowingTag("));
+        assertFalse(gameEvents.contains("setGlowingTag("));
     }
 
     @Test


### PR DESCRIPTION
## 变更说明
- 新增客户端 `C4ItemOutlineMixin`，为掉落 C4 提供轮廓显示逻辑
- 仅在 `cs` 模式且本地玩家属于 `t` 队时显示 C4 轮廓
- 注入 `shouldRenderAtSqrDistance`，提升掉落 C4 在远距离下的渲染可见性
- 在 `blockoffensive.mixins.json` 注册 `client.C4ItemOutlineMixin`
- 回归测试加固：
  - objective 掉落路径禁止使用原版 `setGlowingTag(`
  - 校验 C4 轮廓 mixin 的注册与关键行为

## 影响范围
- `src/main/java/com/phasetranscrystal/blockoffensive/mixin/client/C4ItemOutlineMixin.java`
- `src/main/resources/blockoffensive.mixins.json`
- `src/test/java/com/phasetranscrystal/blockoffensive/issues/BlockOffensiveIssueRegressionTest.java`
- `src/test/java/com/phasetranscrystal/blockoffensive/map/CSIssueSourceGuardTest.java`

## 测试
- 定向回归测试套件在本地执行通过（历史记录中对应 XML 结果均为 `failures=0/errors=0`）