### PR TITLE
fix: MVP winner side source and banner text fitting

### DIFF
--- a/src/main/java/com/phasetranscrystal/blockoffensive/client/screen/hud/CSMvpHud.java
+++ b/src/main/java/com/phasetranscrystal/blockoffensive/client/screen/hud/CSMvpHud.java
@@ -57,13 +57,17 @@ public class CSMvpHud {
     private Component extraInfo1 = Component.empty();
     private Component extraInfo2 = Component.empty();
     private Component mvpReason = Component.empty();
+    private boolean currentWinnerCtTeam = true;
+    private int currentBannerWidthPx = 0;
 
     public void triggerAnimation(MvpReason reason) {
         MinecraftForge.EVENT_BUS.post(new CSHUDRenderEvent.RenderMvpHud.TriggeredAnimation(reason));
         this.player = reason.uuid;
-        this.currentTeamName = reason.getTeamName().copy()
-                .append(Component.translatable("cs.game.winner.mvpNameSub"))
-                .withStyle(ChatFormatting.BOLD);
+        boolean isCtTeam = reason.isCtWinner();
+        this.currentWinnerCtTeam = isCtTeam;
+        this.currentTeamName = isCtTeam
+            ? Component.translatable("blockoffensive.map.cs.winner.ct.round.message").withStyle(ChatFormatting.BOLD)
+            : Component.translatable("blockoffensive.map.cs.winner.t.round.message").withStyle(ChatFormatting.BOLD);
         this.currentPlayerName = reason.getPlayerName().withStyle(ChatFormatting.BOLD);
         this.mvpReason = reason.getMvpReason().withStyle(ChatFormatting.BOLD);
         this.extraInfo1 = reason.getExtraInfo1().withStyle(ChatFormatting.BOLD);
@@ -76,7 +80,6 @@ public class CSMvpHud {
         this.mvpColorTransitionStartTime = -1;
         this.animationPlaying = true;
 
-        boolean isCtTeam = reason.getTeamName().getString().equals("CT");
         if (minecraft.level != null && minecraft.player != null) {
             minecraft.level.playLocalSound(
                     minecraft.player.getOnPos().above(2),
@@ -137,7 +140,34 @@ public class CSMvpHud {
      */
     private void renderRoundVictoryBanner(GuiGraphics guiGraphics, PoseStack pose, float bannerProgress,
                                           float scaleFactor, int screenWidth, int screenHeight, long currentTime) {
-        int scaledWidth = (int) (ROUND_BANNER_WIDTH * scaleFactor);
+        Component leftArrow = Component.literal("»").withStyle(ChatFormatting.BOLD);
+        Component rightArrow = Component.literal("«").withStyle(ChatFormatting.BOLD);
+
+        final float ARROW_SCALE = 3.0f;
+        final float TEXT_SCALE = 3.0f;
+        float combinedArrowScale = scaleFactor * ARROW_SCALE;
+        float combinedTextScale = scaleFactor * TEXT_SCALE;
+
+        int sideBarWidth = Math.max(2, (int) (5 * scaleFactor));
+        int outerPadding = Math.max(6, (int) (10 * scaleFactor));
+        int innerGap = Math.max(4, (int) (8 * scaleFactor));
+        int baseTextWidth = font.width(currentTeamName);
+        int textWidth = (int) (baseTextWidth * combinedTextScale);
+        int arrowWidth = (int) (font.width(leftArrow) * combinedArrowScale);
+        int contentWidth = textWidth + arrowWidth * 2 + innerGap * 2;
+        int requiredWidth = contentWidth + sideBarWidth * 2 + outerPadding * 2;
+
+        int baseWidth = (int) (ROUND_BANNER_WIDTH * scaleFactor);
+        int maxWidth = (int) (screenWidth * 0.92f);
+        int scaledWidth = Math.max(baseWidth, Math.min(requiredWidth, maxWidth));
+
+        int maxTextAreaWidth = scaledWidth - sideBarWidth * 2 - outerPadding * 2 - innerGap * 2 - arrowWidth * 2;
+        if (maxTextAreaWidth > 0 && textWidth > maxTextAreaWidth && baseTextWidth > 0) {
+            float fitScale = (float) maxTextAreaWidth / (float) baseTextWidth;
+            combinedTextScale = Math.max(scaleFactor * 1.6f, Math.min(combinedTextScale, fitScale));
+            textWidth = (int) (baseTextWidth * combinedTextScale);
+        }
+        currentBannerWidthPx = scaledWidth;
         int scaledHeight = (int) (ROUND_BANNER_HEIGHT * scaleFactor);
         int animatedWidth = (int) (scaledWidth * bannerProgress);
         int x = (screenWidth - animatedWidth) / 2;
@@ -154,23 +184,13 @@ public class CSMvpHud {
         guiGraphics.fill(x, y, x + animatedWidth, y + scaledHeight, bgColor);
 
         // 绘制队伍颜色侧边条
-        int teamColor = 0xFF3366FF;
-        int sideBarWidth = (int) (5 * scaleFactor);
+        int teamColor = resolveTeamColor();
         guiGraphics.fill(x, y, x + sideBarWidth, y + scaledHeight, teamColor);
         guiGraphics.fill(x + animatedWidth - sideBarWidth, y, x + animatedWidth, y + scaledHeight, teamColor);
 
         // 横幅完全展开后渲染文本
         if (bannerProgress >= 1f) {
-            // 箭头文本添加粗体
-            Component leftArrow = Component.literal("»").withStyle(ChatFormatting.BOLD);
-            Component rightArrow = Component.literal("«").withStyle(ChatFormatting.BOLD);
-
-            final float ARROW_SCALE = 3.0f;
-            final float TEXT_SCALE = 3.0f;
-            float combinedArrowScale = scaleFactor * ARROW_SCALE;
-            float combinedTextScale = scaleFactor * TEXT_SCALE;
-
-            int rightArrowWidth = (int) (font.width(rightArrow) * scaleFactor);
+            int rightArrowWidth = (int) (font.width(rightArrow) * combinedArrowScale);
             int rightX = x + animatedWidth - sideBarWidth - (int) (10 * scaleFactor) - rightArrowWidth;
             int leftX = x + sideBarWidth + (int) (10 * scaleFactor);
 
@@ -257,7 +277,7 @@ public class CSMvpHud {
         guiGraphics.fill(infoStartX, avatarY,
                 infoStartX + colorBarWidth,
                 avatarY + (int) (COLOR_BAR_HEIGHT * scaleFactor),
-                0x773366FF);
+            withAlpha(resolveTeamColor(), 0x77));
 
         // 渲染MVP原因文本
         renderScaledText(guiGraphics, pose, mvpReason,
@@ -336,6 +356,14 @@ public class CSMvpHud {
                 (int) (startB + (endB - startB) * progress);
     }
 
+    private int resolveTeamColor() {
+        return currentWinnerCtTeam ? 0xFF3366FF : 0xFFFFB400;
+    }
+
+    private int withAlpha(int rgbColor, int alpha) {
+        return (alpha << 24) | (rgbColor & 0x00FFFFFF);
+    }
+
     /**
      * 渲染关闭动画（适配MC缩放）
      */
@@ -368,7 +396,8 @@ public class CSMvpHud {
      */
     private void renderClosingBanner(GuiGraphics guiGraphics, int screenWidth, int screenHeight,
                                      float closingRatio, int color, float scaleFactor) {
-        int originalWidth = (int) (ROUND_BANNER_WIDTH * scaleFactor);
+        int fallbackWidth = (int) (ROUND_BANNER_WIDTH * scaleFactor);
+        int originalWidth = currentBannerWidthPx > 0 ? currentBannerWidthPx : fallbackWidth;
         int currentWidth = (int) (originalWidth * (1 - closingRatio));
         int yPos = (int) (190 * ((float) screenHeight / BASE_HEIGHT));
         int centerX = screenWidth / 2;
@@ -478,6 +507,8 @@ public class CSMvpHud {
         extraInfo1 = Component.empty();
         extraInfo2 = Component.empty();
         player = null;
+        currentWinnerCtTeam = true;
+        currentBannerWidthPx = 0;
     }
 
     /**

--- a/src/main/java/com/phasetranscrystal/blockoffensive/data/MvpReason.java
+++ b/src/main/java/com/phasetranscrystal/blockoffensive/data/MvpReason.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 public class MvpReason{
     public final UUID uuid;
+    private boolean ctWinner;
     private MutableComponent teamName;
     private MutableComponent playerName;
     private MutableComponent mvpReason;
@@ -15,11 +16,20 @@ public class MvpReason{
     private MutableComponent extraInfo2;
     private MvpReason(Builder builder){
         this.uuid = builder.uuid;
+        this.ctWinner = builder.ctWinner;
         this.teamName = builder.teamName;
         this.playerName = builder.playerName == null ? Component.empty() : builder.playerName;
         this.mvpReason = builder.mvpReason == null ? Component.empty() : builder.mvpReason;
         this.extraInfo1 = builder.extraInfo1 == null ? Component.empty() : builder.extraInfo1;
         this.extraInfo2 = builder.extraInfo2 == null ? Component.empty() : builder.extraInfo2;
+    }
+
+    public boolean isCtWinner() {
+        return ctWinner;
+    }
+
+    public void setCtWinner(boolean ctWinner) {
+        this.ctWinner = ctWinner;
     }
 
     public MutableComponent getTeamName() {
@@ -64,6 +74,7 @@ public class MvpReason{
 
     public static class Builder{
         public final UUID uuid;
+        boolean ctWinner;
         MutableComponent teamName;
         MutableComponent playerName;
         MutableComponent mvpReason;
@@ -76,6 +87,10 @@ public class MvpReason{
 
         public Builder setTeamName(MutableComponent teamName){
             this.teamName = teamName;
+            return this;
+        }
+        public Builder setCtWinner(boolean ctWinner){
+            this.ctWinner = ctWinner;
             return this;
         }
         public Builder setPlayerName(MutableComponent playerName){

--- a/src/main/java/com/phasetranscrystal/blockoffensive/map/CSGameMap.java
+++ b/src/main/java/com/phasetranscrystal/blockoffensive/map/CSGameMap.java
@@ -954,6 +954,7 @@ public class CSGameMap extends CSMap{
 
     private MvpReason buildEmptyMvpReason(@NotNull ServerTeam winnerTeam) {
         return new MvpReason.Builder(null)
+                .setCtWinner(isCtWinner(winnerTeam))
                 .setTeamName(Component.literal(winnerTeam.getFixedName()))
                 .setMvpReason(Component.translatable("blockoffensive.mvp.combat"))
                 .build();
@@ -961,12 +962,17 @@ public class CSGameMap extends CSMap{
 
     private MvpReason buildMvpReason(UUID uuid, @NotNull ServerTeam winnerTeam, String playerName, String reasonKey, String infoKey, String musicName) {
         return new MvpReason.Builder(uuid)
+                .setCtWinner(isCtWinner(winnerTeam))
                 .setTeamName(Component.literal(winnerTeam.getFixedName()))
                 .setPlayerName(Component.literal(playerName))
                 .setMvpReason(Component.translatable(reasonKey))
                 .setExtraInfo1(Component.translatable(infoKey, Component.literal(playerName)))
                 .setExtraInfo2(Component.literal(musicName))
                 .build();
+    }
+
+    private boolean isCtWinner(@NotNull ServerTeam winnerTeam) {
+        return winnerTeam.getFixedName().equalsIgnoreCase(getCT().getFixedName());
     }
 
     private String getPlayerName(UUID uuid) {

--- a/src/main/java/com/phasetranscrystal/blockoffensive/net/mvp/MvpMessageS2CPacket.java
+++ b/src/main/java/com/phasetranscrystal/blockoffensive/net/mvp/MvpMessageS2CPacket.java
@@ -17,6 +17,7 @@ public class MvpMessageS2CPacket {
     }
     public static void encode(MvpMessageS2CPacket packet, FriendlyByteBuf buf) {
         buf.writeUUID(packet.mvpReason.uuid);
+        buf.writeBoolean(packet.mvpReason.isCtWinner());
         buf.writeComponent(packet.mvpReason.getTeamName());
         buf.writeComponent(packet.mvpReason.getPlayerName());
         buf.writeComponent(packet.mvpReason.getMvpReason());
@@ -26,6 +27,7 @@ public class MvpMessageS2CPacket {
 
     public static MvpMessageS2CPacket decode(FriendlyByteBuf buf) {
         return new MvpMessageS2CPacket(new MvpReason.Builder(buf.readUUID())
+                .setCtWinner(buf.readBoolean())
                 .setTeamName(buf.readComponent().copy())
                 .setPlayerName(buf.readComponent().copy())
                 .setMvpReason(buf.readComponent().copy())


### PR DESCRIPTION
## Summary
- use server-authoritative winner side (`ctWinner`) in MVP data flow
- stop deriving winner side from client team-name text
- make victory banner width/text scaling adaptive to avoid overflow on long localized strings
- align closing animation width with the expanded banner width

## Scope
This PR only includes MVP-related changes:
- `src/main/java/com/phasetranscrystal/blockoffensive/data/MvpReason.java`
- `src/main/java/com/phasetranscrystal/blockoffensive/net/mvp/MvpMessageS2CPacket.java`
- `src/main/java/com/phasetranscrystal/blockoffensive/map/CSGameMap.java`
- `src/main/java/com/phasetranscrystal/blockoffensive/client/screen/hud/CSMvpHud.java`

## Validation
- local build passed before PR creation
- MVP regression scenario verified: winner side rendering now follows server result and banner no longer overflows for long text